### PR TITLE
Notify user of unsaved changes before unloading

### DIFF
--- a/apps/website/src/components/editor/execute-bar/index.tsx
+++ b/apps/website/src/components/editor/execute-bar/index.tsx
@@ -57,7 +57,7 @@ export function ExecuteBar({ runtime }: { runtime: PartialRuntime }) {
   // Form
 
   const form = useForm<ExecuteOptions>({
-    resolver: zodResolver(ExecuteOptions),
+    resolver: zodResolver(ExecuteOptions as never),
     defaultValues: {},
   });
   const handleSubmit = useCallback<ReturnType<typeof form.handleSubmit>>(

--- a/apps/website/src/components/explorer/use.tsx
+++ b/apps/website/src/components/explorer/use.tsx
@@ -48,6 +48,21 @@ export function ExplorerProvider({
     return root;
   }, []);
 
+  const [hasChange, setHasChange] = useState(false);
+  useEffect(() => {
+    const onChange = () => setHasChange(true);
+    root.changes.on(['child', '*'], onChange);
+    return () => void root.changes.off(['child', '*'], onChange);
+  }, [root]);
+
+  const beforeUnload = useCallback(
+    (e: Event) => {
+      if (hasChange) e.preventDefault();
+    },
+    [hasChange],
+  );
+  useEventListener('beforeunload', beforeUnload);
+
   const saveAndCopyUrl = useCallback(
     (e: Event) => {
       e.preventDefault();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning prompt to prevent users from accidentally leaving the page when there are unsaved changes in the explorer.

- **Bug Fixes**
  - Improved detection of changes within the explorer to better track unsaved modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->